### PR TITLE
remove UPSTREAM_WORKSPACE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
-# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
+# This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci package.
 sudo: required
 dist: xenial
 services:
   - docker
 language: cpp
-cache: ccache
 compiler: gcc
+cache: ccache
 
 notifications:
   email:
     recipients:
+
 env:
   global:
     - ROS_DISTRO=melodic
-    - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
   matrix:
-    - DOCKER_IMAGE=moveit/moveit:master-source   TEST=clang-format,catkin_lint
+    - TEST=clang-format,catkin_lint
     - DOCKER_IMAGE=moveit/moveit:master-source
 
 before_script:


### PR DESCRIPTION
Cleanup Travis config: Using the source-build container, there is no need to rebuild all MoveIt packages.